### PR TITLE
Stable/2024.1

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -2,3 +2,4 @@
 host=review.opendev.org
 port=29418
 project=openstack/sushy.git
+defaultbranch=stable/2024.1

--- a/releasenotes/notes/accept-encoding-4646ea43998f80bd.yaml
+++ b/releasenotes/notes/accept-encoding-4646ea43998f80bd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Adds a work-around for cases where ``Accept-Encoding: identity`` is not
+    accepted.

--- a/releasenotes/notes/retry-on-missing-managedby-b2a5240eab8b4262.yaml
+++ b/releasenotes/notes/retry-on-missing-managedby-b2a5240eab8b4262.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Adds the ability to retry an attempt to determine a Manager for a System
+    when ManagedBy attribute is missing but Managers attribute is present.
+    This resolves issues with certain hardware models such as Huawei 1288H.

--- a/releasenotes/notes/storage-controller-name-6924b71a97f78481.yaml
+++ b/releasenotes/notes/storage-controller-name-6924b71a97f78481.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The ``Name`` field of a StorageControllers sub-field of a Storage resource
+    is no longer mandatory.

--- a/sushy/exceptions.py
+++ b/sushy/exceptions.py
@@ -160,6 +160,10 @@ class AccessError(HTTPError):
     pass
 
 
+class NotAcceptableError(HTTPError):
+    pass
+
+
 class MissingXAuthToken(HTTPError):
     message = ('No X-Auth-Token returned from remote host when '
                'attempting to establish a session. Error: %(error)s')
@@ -176,6 +180,8 @@ def raise_for_response(method, url, response):
     elif response.status_code in (http_client.UNAUTHORIZED,
                                   http_client.FORBIDDEN):
         raise AccessError(method, url, response)
+    elif response.status_code == http_client.NOT_ACCEPTABLE:
+        raise NotAcceptableError(method, url, response)
     elif response.status_code >= http_client.INTERNAL_SERVER_ERROR:
         raise ServerSideError(method, url, response)
     else:

--- a/sushy/resources/system/storage/storage.py
+++ b/sushy/resources/system/storage/storage.py
@@ -34,7 +34,7 @@ class StorageControllersListField(base.ListField):
     member_id = base.Field('MemberId', required=True)
     """Uniquely identifies the member within the collection."""
 
-    name = base.Field('Name', required=True)
+    name = base.Field('Name')
     """The name of the storage controller"""
 
     status = common.StatusField('Status')

--- a/sushy/tests/unit/json_samples/storage.json
+++ b/sushy/tests/unit/json_samples/storage.json
@@ -17,7 +17,6 @@
             "@odata.id": "/redfish/v1/Systems/437XR1138R2/Storage/1#/StorageControllers/0",
             "@odata.type": "#Storage.v1_3_0.StorageController",
             "MemberId": "0",
-            "Name": "Contoso Integrated RAID",
             "Status": {
                 "@odata.type": "#Resource.Status",
                 "State": "Enabled",

--- a/sushy/tests/unit/json_samples/system_managedby_missing_manager_present.json
+++ b/sushy/tests/unit/json_samples/system_managedby_missing_manager_present.json
@@ -1,0 +1,166 @@
+{
+    "@odata.type": "#ComputerSystem.v1_10_0.ComputerSystem",
+    "Id": "437XR1138R2",
+    "Name": "WebFrontEnd483",
+    "SystemType": "Physical",
+    "AssetTag": "Chicago-45Z-2381",
+    "Manufacturer": "Contoso",
+    "Model": "3500",
+    "SubModel": "RX",
+    "SKU": "8675309",
+    "SerialNumber": "437XR1138R2",
+    "PartNumber": "224071-J23",
+    "Description": "Web Front End node",
+    "UUID": "38947555-7742-3448-3784-823347823834",
+    "HostName": "web483",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollup": "OK"
+    },
+    "HostingRoles": [
+    "ApplicationServer"
+    ],
+    "IndicatorLED": "Off",
+    "PowerState": "On",
+    "Boot": {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Cd",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "Utilities",
+            "Diags",
+            "SDCard",
+            "UefiTarget",
+            "UefiHttp"
+        ],
+        "BootSourceOverrideMode": "UEFI",
+        "UefiTargetBootSourceOverride": "/0x31/0x33/0x01/0x01",
+        "HttpBootUri": "https://Contoso.lan/boot.iso"
+    },
+    "BootProgress": {
+        "LastBootTimeSeconds": 66,
+         "LastState": "OSRunning",
+        "LastStateTime": "2017-05-03T23:12:37-05:00",
+        "OemLastState": "OS foo running."
+    },
+    "TrustedModules": [
+        {
+            "FirmwareVersion": "1.13b",
+            "InterfaceType": "TPM1_2",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            }
+        }
+    ],
+    "Oem": {
+        "Contoso": {
+            "@odata.type": "#Contoso.ComputerSystem",
+            "Name": "Contoso OEM system",
+            "ProductionLocation": {
+                "FacilityName": "PacWest Production Facility",
+                "Country": "USA"
+            }
+        },
+        "Chipwise": {
+            "@odata.type": "#Chipwise.ComputerSystem",
+            "Style": "Executive"
+        }
+    },
+    "BiosVersion": "P79 v1.45 (12/06/2017)",
+    "ProcessorSummary": {
+        "Count": 2,
+        "ProcessorFamily": "Multi-Core Intel(R) Xeon(R) processor 7xxx Series",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 96,
+        "TotalSystemPersistentMemoryGiB": 0,
+        "MemoryMirroring": "None",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        }
+    },
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Bios"
+    },
+    "SecureBoot": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/SecureBoot"
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors"
+    },
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces"
+    },
+    "SimpleStorage": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1U"
+            }
+        ],
+        "Managers": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/437XR1138R2/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton"
+            ],
+            "@Redfish.OperationApplyTimeSupport": {
+                "@odata.type": "#Settings.v1_2_0.OperationApplyTimeSupport",
+                "SupportedValues": [ "Immediate", "AtMaintenanceWindowStart" ],
+                "MaintenanceWindowStartTime": "2017-05-03T23:12:37-05:00",
+                "MaintenanceWindowDurationInSeconds": 600,
+                "MaintenanceWindowResource": {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            }
+        },
+        "Oem": {
+            "#Contoso.Reset": {
+                "target": "/redfish/v1/Systems/437XR1138R2/Oem/Contoso/Actions/Contoso.Reset"
+            }
+        }
+    },
+    "@Redfish.MaintenanceWindow": {
+        "@odata.type": "#Settings.v1_2_0.MaintenanceWindow",
+        "MaintenanceWindowDurationInSeconds": 1,
+        "MaintenanceWindowStartTime": "2016-03-07T14:44:30-05:05"
+    },
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2",
+    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/sushy/tests/unit/resources/system/storage/test_storage.py
+++ b/sushy/tests/unit/resources/system/storage/test_storage.py
@@ -125,7 +125,6 @@ class StorageTestCase(base.TestCase):
         self.assertEqual(1, len(controllers))
         controller = controllers[0]
         self.assertEqual('0', controller.member_id)
-        self.assertEqual('Contoso Integrated RAID', controller.name)
         self.assertEqual(res_cons.Health.OK, controller.status.health)
         self.assertEqual(res_cons.State.ENABLED, controller.status.state)
         identifiers = controller.identifiers

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
    VIRTUAL_ENV={envdir}
    PYTHONWARNINGS=default::DeprecationWarning
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
   -r{toxinidir}/test-requirements.txt
   -r{toxinidir}/requirements.txt
 commands = stestr run --slowest {posargs}
@@ -21,13 +21,13 @@ deps=
     hacking~=6.0.0 # Apache-2.0
     flake8-import-order>=0.17.1 # LGPLv3
     pycodestyle>=2.0.0,<3.0.0 # MIT
-    -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+    -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
 commands = flake8 {posargs}
 
 [testenv:venv]
 setenv = PYTHONHASHSEED=0
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
   -r{toxinidir}/doc/requirements.txt
@@ -48,7 +48,7 @@ commands = coverage erase
            coverage xml -o cover/coverage.xml
 
 [testenv:docs]
-deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/doc/requirements.txt
 commands = sphinx-build -W -b html doc/source doc/build/html
@@ -56,14 +56,14 @@ commands = sphinx-build -W -b html doc/source doc/build/html
 [testenv:pdf-docs]
 usedevelop = False
 allowlist_externals = make
-deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
        -r{toxinidir}/doc/requirements.txt
 commands = sphinx-build -b latex doc/source doc/build/pdf
            make -C doc/build/pdf
 
 [testenv:releasenotes]
 usedevelop = False
-deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+deps = -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
        -r{toxinidir}/doc/requirements.txt
 commands =
   sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html


### PR DESCRIPTION
### Description

This pull request includes several modifications across various files in the project:

- Modified `.gitreview` to update the default branch to `stable/2024.1`.
- Added release notes for different fixes:
  - A work-around for cases where `Accept-Encoding: identity` is not accepted.
  - The ability to retry an attempt to determine a Manager for a System when ManagedBy attribute is missing but Managers attribute is present.
  - The `Name` field of a StorageControllers sub-field of a Storage resource is no longer mandatory.
- Various modifications in the `sushy` package files:
  - `sushy/connector.py` and `sushy/exceptions.py` were modified.
  - Modifications in the system and storage resources files (`sushy/resources/system/storage/storage.py` and `sushy/resources/system/system.py`).
  - Addition of a test file (`sushy/tests/unit/json_samples/system_managedby_missing_manager_present.json`).
  - Modifications in the test files for system and storage resources.
  - Update to the tests in `sushy/tests/unit/test_connector.py`.
- Addition of the ability to retry without `Accept-Encoding: identity` header in the Connector class when `NotAcceptableError` occurs.
- Updates in the `get_sub_resource_path_by` method in the `system.py` file in case the ManagedBy attribute is missing.
- Updates to the accept-encoding header handling in the `_op` method of the Connector class.
- Various modifications in the `storage.json` test sample file.
- Minor modifications in the `tox.ini` file for setting constraints for dependencies.

These changes aim to address specific issues and improvements related to handling certain hardware models like Huawei 1288H and addressing potential compatibility issues with BMC where certain headers or attributes are missing.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the default branch to `stable/2024.1`, add workarounds for `Accept-Encoding` issues, allow retrying on missing `ManagedBy` attributes, make the `Name` field in `StorageControllers` optional, and update Tox constraints to `2024.1`.

### Why are these changes being made?

These changes address compatibility and functionality issues with certain hardware models, such as Huawei 1288H and HPE Gen 10 Plus, by providing necessary workarounds and retries. The update to the `stable/2024.1` branch and Tox constraints ensures alignment with the latest stable release, while making the `Name` field optional increases flexibility in handling storage resources.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->